### PR TITLE
Fix typo in front-end/main.js

### DIFF
--- a/front-end/main.js
+++ b/front-end/main.js
@@ -26,6 +26,6 @@ function onAddItem(item) {
 
 function onEditItem(item) {
     const index = list.lastIndexOf(item);
-    list[index] = editedItem;
+    list[index] = item;
     renderShoppingList(list);
 }


### PR DESCRIPTION
Literówka ta sprawiała, że tekst nie stawał się przekreślony po zaznaczeniu okienka. Na filmie również jest tam wartość `item`.